### PR TITLE
Myth bestiary patch

### DIFF
--- a/Sources/Modules/Myth/Bosses/Acytaea/NPCs/Acytaea.cs
+++ b/Sources/Modules/Myth/Bosses/Acytaea/NPCs/Acytaea.cs
@@ -1963,7 +1963,7 @@ public class Acytaea : VisualNPC
 
 				new FlavorTextBestiaryInfoElement(tx1),
 			new FlavorTextBestiaryInfoElement(tx2),
-			new FlavorTextBestiaryInfoElement("Mods.MythMod.Bestiary.Acytaea")
+			new FlavorTextBestiaryInfoElement("Mods.Everglow.Bestiary.Acytaea")
 		});
 	}
 

--- a/Sources/Modules/Myth/TheFirefly/NPCs/Centipede.cs
+++ b/Sources/Modules/Myth/TheFirefly/NPCs/Centipede.cs
@@ -1,4 +1,4 @@
-﻿using Everglow.Myth.Common;
+using Everglow.Myth.Common;
 using Terraria;
 using Terraria.Audio;
 using Terraria.DataStructures;
@@ -21,7 +21,7 @@ internal class CentipedeHead : FireWormHead
 	{
 		var drawModifier = new NPCID.Sets.NPCBestiaryDrawModifiers(0)
 		{
-			CustomTexturePath = "TheFirefly/NPCs/FireflyCentipede_Bestiary",
+			CustomTexturePath = "Everglow/Myth/TheFirefly/NPCs/FireflyCentipede_Bestiary",
 			Position = new Vector2(40f, 24f),
 			PortraitPositionXOverride = 0f,
 			PortraitPositionYOverride = 12f


### PR DESCRIPTION
This PR fixes issues with the bestiary path for the firefly centipede, which causes client log message flooding and game freezes with mods that utilize NPC display and spawning functions (DragonLens in this case, which I use now)

Changes:
- Typo fix for Acytaea.cs. "MythMod" -> "Everglow"
- Path fix for Centipede.cs